### PR TITLE
fix: Autopass instance should be closed on teardown to gc DHT etc

### DIFF
--- a/backend/backend.mjs
+++ b/backend/backend.mjs
@@ -29,6 +29,7 @@ fs.mkdirSync(path)
 const invite = Bare.argv[1]
 const pair = Autopass.pair(new Corestore(path), invite)
 const pass = await pair.finished()
+Bare.on('teardown', () => pass.close())
 
 await pass.ready()
 


### PR DESCRIPTION
Will speed up subsequent reruns as users explore building mobile apps on Bare.