### PR TITLE
Pass documents directory URL to worklet

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -5,10 +5,10 @@ import {
   TextInput,
   Button,
   FlatList,
-  Platform,
   Alert,
   StyleSheet
 } from 'react-native'
+import { documentDirectory } from 'expo-file-system'
 import Clipboard from '@react-native-clipboard/clipboard'
 import { Worklet } from 'react-native-bare-kit'
 import bundle from './app.bundle'
@@ -31,7 +31,7 @@ export default function App() {
     const worklet = new Worklet()
 
     // Correctly passing the args to worklet.start
-    worklet.start('/app.bundle', bundle, [Platform.OS, pairingInvite])
+    worklet.start('/app.bundle', bundle, [String(documentDirectory), pairingInvite])
     const { IPC } = worklet
     // Initialise RPC
     new RPC(IPC, (req) => {

--- a/backend/backend.mjs
+++ b/backend/backend.mjs
@@ -2,16 +2,15 @@
 
 import RPC from 'bare-rpc'
 import fs from 'bare-fs'
+import URL from 'bare-url'
+import { join } from 'bare-path'
 import { RPC_RESET, RPC_MESSAGE } from '../rpc-commands.mjs'
 
 import Autopass from 'autopass'
 import Corestore from 'corestore'
 const { IPC } = BareKit
 
-const path =
-  Bare.argv[0] === 'android'
-    ? '/data/data/to.holepunch.bare.expo/autopass-example'
-    : './tmp/autopass-example/'
+const path = join(URL.fileURLToPath(Bare.argv[0]), 'autopass-example')
 
 const rpc = new RPC(IPC, (req, error) => {
   // Handle two way communication here


### PR DESCRIPTION
Previously the OS platform was passed and the path for the example app's corestore was hard coded. The hard coded value did not work on an actual iOS device returning an `EPERM` error. Instead the Documents directory for the app is passed (provided by `expo-file-system`) and the Bare worklet creates a `autopass-example` directory for the `Autopass` corestore.

Note that this does not check for `documentDirectory` returning `null`.