### PR TITLE
Add `.mjs` extension to `app.bundle` import to avoid IDE's complaining

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -11,7 +11,7 @@ import {
 import { documentDirectory } from 'expo-file-system'
 import Clipboard from '@react-native-clipboard/clipboard'
 import { Worklet } from 'react-native-bare-kit'
-import bundle from './app.bundle'
+import bundle from './app.bundle.mjs'
 import RPC from 'bare-rpc'
 import b4a from 'b4a'
 import { RPC_RESET, RPC_MESSAGE } from '../rpc-commands.mjs'


### PR DESCRIPTION
Not an actual bug, but IDEs expect an extension and warn developers.

Already changed in the guide: https://github.com/holepunchto/pear-docs/pull/192